### PR TITLE
Fix documentation for temperature conversion

### DIFF
--- a/src/Insect/Functions.purs
+++ b/src/Insect/Functions.purs
@@ -49,7 +49,7 @@ fromFahrenheit tempFahrenheit' = do
   pure $ ((tempFahrenheit + offsetFahrenheit) * multiplierFahrenheit) .* Q.kelvin
 
 -- | Convert a quantity in Kelvin (K) to a scalar that can be interpreted as
--- | the value in degree Celsius (°C).
+-- | the value in degree Fahrenheit (°F).
 -- | Type signature in physical units: kelvin => scalar
 toFahrenheit ∷ Quantity → Either ConversionError Quantity
 toFahrenheit tempKelvin' = do


### PR DESCRIPTION
## Summary
- fix typo in Fahrenheit function documentation

## Testing
- `npm test` *(fails: spago not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402a3f352483328886e4cd6e3519e5