### PR TITLE
Add fertility tracker Telegram bot for AWS Lambda

### DIFF
--- a/docs/fertility-bot-lambda.md
+++ b/docs/fertility-bot-lambda.md
@@ -1,0 +1,40 @@
+# Fertility tracker Telegram bot (AWS Lambda)
+
+This mini app adds a Telegram webhook handler that records cycle starts and reports a predicted ovulation and fertile window. It is shipped as an independent Lambda function under `lambda/fertility-bot`.
+
+## Features
+
+- `/start` — send onboarding help.
+- `/log YYYY-MM-DD` — store the first day of a cycle in DynamoDB.
+- `/stats` — calculate an average cycle length and report the next period, ovulation, and fertile window.
+- Optional webhook secret validation via the `X-Telegram-Bot-Api-Secret-Token` header.
+
+## Deployment
+
+1. Create a DynamoDB table (for example `FertilityTrackerCycles`) with the following keys:
+   - Partition key: `chatId` (String)
+   - Sort key: `cycleStart` (String, `YYYY-MM-DD`)
+2. Deploy the Lambda with a Node.js 18 runtime and the code from `lambda/fertility-bot/index.js`.
+3. Install dependencies inside `lambda/fertility-bot` and bundle them with the deployment artifact:
+
+   ```bash
+   cd lambda/fertility-bot
+   npm install
+   zip -r fertility-bot.zip .
+   ```
+
+4. Set these environment variables on the function:
+   - `TELEGRAM_BOT_TOKEN`: Telegram bot token
+   - `CYCLE_TABLE_NAME`: DynamoDB table name (defaults to `FertilityTrackerCycles`)
+   - `TELEGRAM_WEBHOOK_SECRET`: optional secret to match `X-Telegram-Bot-Api-Secret-Token`
+   - `TELEGRAM_API_URL`: override if using a self-hosted Telegram gateway
+   - `AWS_REGION`: AWS region for the DynamoDB client
+5. Expose the Lambda through API Gateway (HTTP API). Configure the Telegram webhook to call that endpoint and include the same webhook secret if you set one:
+
+   ```bash
+   curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
+     -d url="https://<api-id>.execute-api.<region>.amazonaws.com/telegram" \
+     -d secret_token="$TELEGRAM_WEBHOOK_SECRET"
+   ```
+
+The handler will respond with a simple `ok` to Telegram and post the results back to the chat via `sendMessage`.

--- a/lambda/fertility-bot/index.js
+++ b/lambda/fertility-bot/index.js
@@ -1,0 +1,169 @@
+import { DynamoDBClient, PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
+
+const botToken = process.env.TELEGRAM_BOT_TOKEN;
+const telegramApiUrl = process.env.TELEGRAM_API_URL ?? "https://api.telegram.org";
+const webhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
+const tableName = process.env.CYCLE_TABLE_NAME ?? "FertilityTrackerCycles";
+const region = process.env.AWS_REGION ?? "us-east-1";
+
+const dynamo = new DynamoDBClient({ region });
+
+const TEXT = {
+  welcome: `Hi! I'm your fertility tracker bot.
+Send /log YYYY-MM-DD to record the first day of your cycle.
+Send /stats to see your next expected period, ovulation, and fertile window.`,
+  invalidLog: "Please provide a date in YYYY-MM-DD format, for example /log 2024-05-02.",
+  stored: (date) => `Logged your cycle start on ${date}.`,
+  noHistory: "I don't have enough history to make a prediction yet. Log at least one cycle start with /log YYYY-MM-DD.",
+};
+
+const dateOnly = (value) => value.toISOString().slice(0, 10);
+
+const isValidDate = (value) => !Number.isNaN(value?.getTime?.());
+
+const daysBetween = (a, b) => Math.round((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24));
+
+async function sendTelegramMessage(chatId, text) {
+  if (!botToken) {
+    console.warn("Missing TELEGRAM_BOT_TOKEN; skipping Telegram call");
+    return;
+  }
+
+  const url = `${telegramApiUrl}/bot${botToken}/sendMessage`;
+  await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text }),
+  });
+}
+
+async function storeCycleStart(chatId, cycleStart) {
+  const command = new PutItemCommand({
+    TableName: tableName,
+    Item: {
+      chatId: { S: chatId },
+      cycleStart: { S: cycleStart },
+      createdAt: { S: new Date().toISOString() },
+    },
+  });
+
+  await dynamo.send(command);
+}
+
+async function getCycleHistory(chatId) {
+  const command = new QueryCommand({
+    TableName: tableName,
+    KeyConditionExpression: "chatId = :chatId",
+    ExpressionAttributeValues: { ":chatId": { S: chatId } },
+    ScanIndexForward: true,
+  });
+
+  const result = await dynamo.send(command);
+  return (result.Items ?? []).map((item) => new Date(item.cycleStart.S)).sort((a, b) => a - b);
+}
+
+function buildPrediction(history) {
+  if (history.length === 0) {
+    return null;
+  }
+
+  const averageCycleLength = history.length > 1
+    ? Math.round(
+        history.slice(1).reduce((total, date, index) => total + daysBetween(history[index], date), 0) /
+          (history.length - 1)
+      )
+    : 28;
+
+  const lastStart = history[history.length - 1];
+  const nextPeriod = new Date(lastStart);
+  nextPeriod.setDate(nextPeriod.getDate() + averageCycleLength);
+
+  const ovulation = new Date(lastStart);
+  ovulation.setDate(ovulation.getDate() + averageCycleLength - 14);
+
+  const fertileFrom = new Date(ovulation);
+  fertileFrom.setDate(fertileFrom.getDate() - 5);
+
+  const fertileTo = new Date(ovulation);
+  fertileTo.setDate(fertileTo.getDate() + 1);
+
+  return {
+    averageCycleLength,
+    lastStart: dateOnly(lastStart),
+    nextPeriod: dateOnly(nextPeriod),
+    ovulation: dateOnly(ovulation),
+    fertileFrom: dateOnly(fertileFrom),
+    fertileTo: dateOnly(fertileTo),
+  };
+}
+
+function unauthorizedResponse() {
+  return { statusCode: 401, body: "invalid secret" };
+}
+
+function okResponse() {
+  return { statusCode: 200, body: "ok" };
+}
+
+export const handler = async (event) => {
+  if (webhookSecret) {
+    const provided = event.headers?.["x-telegram-bot-api-secret-token"] ?? event.headers?.["X-Telegram-Bot-Api-Secret-Token"];
+    if (provided !== webhookSecret) {
+      return unauthorizedResponse();
+    }
+  }
+
+  const body = event.body ? JSON.parse(event.body) : {};
+  const message = body.message ?? body.edited_message;
+
+  const text = message?.text?.trim();
+  const chatId = message?.chat?.id;
+
+  if (!text || !chatId) {
+    return okResponse();
+  }
+
+  if (text.startsWith("/start")) {
+    await sendTelegramMessage(chatId, TEXT.welcome);
+    return okResponse();
+  }
+
+  if (text.startsWith("/log")) {
+    const [, dateInput] = text.split(/\s+/, 2);
+    const parsedDate = new Date(`${dateInput}T00:00:00Z`);
+
+    if (!dateInput || !isValidDate(parsedDate)) {
+      await sendTelegramMessage(chatId, TEXT.invalidLog);
+      return okResponse();
+    }
+
+    const value = dateOnly(parsedDate);
+    await storeCycleStart(String(chatId), value);
+    await sendTelegramMessage(chatId, TEXT.stored(value));
+    return okResponse();
+  }
+
+  if (text.startsWith("/stats")) {
+    const history = await getCycleHistory(String(chatId));
+    const prediction = buildPrediction(history);
+
+    if (!prediction) {
+      await sendTelegramMessage(chatId, TEXT.noHistory);
+      return okResponse();
+    }
+
+    const summary = [
+      `Last logged start: ${prediction.lastStart}`,
+      `Avg cycle length: ${prediction.averageCycleLength} days`,
+      `Next period: ${prediction.nextPeriod}`,
+      `Ovulation: ${prediction.ovulation}`,
+      `Fertile window: ${prediction.fertileFrom} → ${prediction.fertileTo}`,
+    ].join("\n");
+
+    await sendTelegramMessage(chatId, summary);
+    return okResponse();
+  }
+
+  await sendTelegramMessage(chatId, "I can log your cycle with /log YYYY-MM-DD and show insights with /stats.");
+  return okResponse();
+};

--- a/lambda/fertility-bot/package.json
+++ b/lambda/fertility-bot/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fertility-tracker-bot",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Telegram mini app webhook for fertility tracking, designed for AWS Lambda.",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.632.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone Telegram webhook handler for fertility tracking that runs on AWS Lambda
- log cycle starts in DynamoDB and compute predicted ovulation and fertile window
- document deployment steps and required environment variables for the mini app

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f4737ac88332a13189a35dbd9f95)